### PR TITLE
Add link to phd milestones listed by the department

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Grad school has too many [unwritten rules](https://www.insidehighered.com/advice
 
 So as I'm working through grad school, I'm trying to keep track of all these steps to shed light on the confusing processes. Please note that my experiences, and this information, may only really be applicable to other grad students in CEE Hydrology. Other sections of the CEE department may do things quite differently. This no doubt adds to the confusion that grad students are confronted with, since some of these processes are conducted seemingly on an ad-hoc basis subject to your faculty advisors' idea of how exams should be structured, and not centrally coordinated by the department.
 
+The milestones for getting a PhD from the department are listed [here](https://www.ce.washington.edu/current/phd/milestones). This guide is structured based on the major milestones required for the PhD. These being the [Qualifying exam](how-to-graduate/2-qual-exam.md), the [General Exam](how-to-graduate/3-gen-exam.md) and the [Final exam](how-to-graduate/4-final-exam.md). Optionally students may also choose to get a [master's degree](how-to-graduate/1-masters-defense.md) before starting their PhD, which is a recommended track in some labs.
+
 Shout out to my fellow grad students who shared info with me or helped me with this. Please [fork this repo](https://github.com/spestana/how-to-graduate/) or [contact me](mailto:spestana@uw.edu) to add/edit more information or to help correct typos.
 
 ---


### PR DESCRIPTION
Each individual page had a link to their respective milestone page in the department. However the link to all the milestones listed together was missing. Added the link in the README.md and added a paragraph on how the guide is structured.